### PR TITLE
Remove index from files column in ScanResultRecord for improved datab…

### DIFF
--- a/db/scan_result.py
+++ b/db/scan_result.py
@@ -15,7 +15,7 @@ class ScanResultRecord(Base):
     root_path: Mapped[str] = mapped_column(String, nullable=False, index=True)
     scan_type: Mapped[str] = mapped_column(String, nullable=False, index=True)
     scan_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    files: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True, index=True)
+    files: Mapped[Optional[List[str]]] = mapped_column(JSON, nullable=True)
     scan_start: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )


### PR DESCRIPTION
This pull request makes a minor change to the `ScanResultRecord` model in `db/scan_result.py` by removing the index on the `files` column. This simplifies the database schema and may improve performance for certain operations.

- Database schema update:
  * Removed the `index=True` option from the `files` column in the `ScanResultRecord` model, so this JSON field is no longer indexed in the database.…ase performance.